### PR TITLE
Don't try to instrument when trapping.

### DIFF
--- a/lib/queue_kit/signal_checker.rb
+++ b/lib/queue_kit/signal_checker.rb
@@ -36,7 +36,6 @@ module QueueKit
       debug :setup, sig
 
       old_handler = trap sig do
-        debug :trap, sig
         @handler.send(trap_method, @worker)
         old_handler.call if old_handler.respond_to?(:call)
       end

--- a/lib/queue_kit/worker.rb
+++ b/lib/queue_kit/worker.rb
@@ -68,13 +68,11 @@ module QueueKit
     end
 
     def start
-      instrument "worker.start"
       set_popping_procline
       @stopped = false
     end
 
     def stop
-      instrument "worker.stop"
       @stopped = true
     end
 


### PR DESCRIPTION
Ruby gets :sob: at the mutex synchronisation necessary to do instrumentation when in a trap context and raises a `ThreadError`.

CC @github/hooks @technoweenie @kdaigle for review. May also make sense to make another release with this.